### PR TITLE
Use permanent links to library sources.

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -40,7 +40,7 @@ $(eval $(call addlib_s,libzlib,$(CONFIG_LIBZLIB)))
 # Original sources
 ################################################################################
 LIBZLIB_VERSION=1.2.13
-LIBZLIB_URL=http://www.zlib.net/zlib-$(LIBZLIB_VERSION).tar.gz
+LIBZLIB_URL=http://www.zlib.net/fossils/zlib-$(LIBZLIB_VERSION).tar.gz
 LIBZLIB_DIR=zlib-$(LIBZLIB_VERSION)
 
 $(eval $(call fetch,libzlib,$(LIBZLIB_URL),$(LIBZLIB_VERSION).tar.gz))


### PR DESCRIPTION
All zlib versions are stored in the fossils/ path of the website. Use this path to avoid link rot.

Signed-off-by: Tu Dinh Ngoc <dinhngoc.tu@irit.fr>