### PR TITLE
Config.uk: Do not enable lib by default

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,6 +1,6 @@
 config LIBZLIB
 	   bool "zlib - a compression library"
-	   default y
+	   default n
 	   depends on HAVE_LIBC
 	   select LIBVFSCORE
 	   select LIBRAMFS


### PR DESCRIPTION
This change makes lib-zlib not enable itself by default when included in the build, bringing it in line with other libraries.