### PR TITLE
lib-zlib: Update library to 1.3

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -39,7 +39,7 @@ $(eval $(call addlib_s,libzlib,$(CONFIG_LIBZLIB)))
 ################################################################################
 # Original sources
 ################################################################################
-LIBZLIB_VERSION=1.2.13
+LIBZLIB_VERSION=1.3
 LIBZLIB_URL=http://www.zlib.net/fossils/zlib-$(LIBZLIB_VERSION).tar.gz
 LIBZLIB_DIR=zlib-$(LIBZLIB_VERSION)
 


### PR DESCRIPTION
Issue #9 
At line 42 in `Makefile.uk` update version from `LIBZLIB_VERSION=1.2.13` to `LIBZLIB_VERSION=1.3` (latest).
