### PR TITLE
fix(Config.uk): Remove hard vfscore stack and leave it to the application

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -2,6 +2,4 @@ config LIBZLIB
 	   bool "zlib - a compression library"
 	   default y
 	   depends on HAVE_LIBC
-	   select LIBVFSCORE
-	   select LIBRAMFS
-	   select LIBDEVFS
+


### PR DESCRIPTION
This pr removes the hardcoded vfscore stack selection from `Config.uk`. The change is needed because Unikraft now uses the posix-vfs stack and vfscore is deprecated, so forcing it here can break or conflict with newer applications. By dropping the forced selection, the application embedding lib-zlib can choose the appropriate vfs stack themselves.